### PR TITLE
PostgreSQL undefined column fix.

### DIFF
--- a/src/services/TrendingPostsService.php
+++ b/src/services/TrendingPostsService.php
@@ -87,7 +87,7 @@ class TrendingPostsService extends Component
         // @todo  Move this to cron task    
         Craft::$app->getDb()->createCommand()
         ->delete($this->trendingposts,
-                '[[dateCreated]] <= "'.$minusTrackDate.'"'
+                "[[dateCreated]] <= '".$minusTrackDate."'"
                 )
         ->execute();
 
@@ -97,7 +97,7 @@ class TrendingPostsService extends Component
                 'and',
                 ['entryId' => $entryId],
                 ['userIp' => $_SERVER['REMOTE_ADDR']],
-                '[[dateCreated]] >= "'.$yesterday.'"',
+                "[[dateCreated]] >= '".$yesterday."'",
             ])
             ->all();
 


### PR DESCRIPTION
> PostgreSQL uses only single quotes for this (i.e. WHERE name = 'John'). Double quotes are used to quote system identifiers; field names, table names, etc. (i.e. WHERE "last name" = 'Smith').
&mdash; [wiki.postgresql.org](https://wiki.postgresql.org/wiki/Things_to_find_out_about_when_moving_from_MySQL_to_PostgreSQL)

To account for this I just swapped the use of single/double quotes.
See the error below:

![image](https://user-images.githubusercontent.com/22011451/60672223-b4e3df00-9e6c-11e9-8cf5-0f2275c0ee5c.png)
